### PR TITLE
Feature/task 1 Add commands for omp-bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+/.idea
+/bot

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -10,7 +10,10 @@ import (
 )
 
 func main() {
-	_ = godotenv.Load()
+	err := godotenv.Load()
+	if err != nil {
+		log.Fatal("Error loading .env file")
+	}
 
 	token, found := os.LookupEnv("TOKEN")
 	if !found {

--- a/internal/app/commands/work/comander.go
+++ b/internal/app/commands/work/comander.go
@@ -1,6 +1,8 @@
 package work
 
 import (
+	"log"
+
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/ozonmp/omp-bot/internal/app/commands/work/team"
 	"github.com/ozonmp/omp-bot/internal/app/path"
@@ -23,5 +25,23 @@ func NewWorkCommander(
 		bot: bot,
 		// teamCommander
 		teamCommander: team.NewWorkTeamCommander(bot),
+	}
+}
+
+func (c *WorkCommander) HandleCallback(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath) {
+	switch callbackPath.Subdomain {
+	case "team":
+		c.teamCommander.HandleCallback(callback, callbackPath)
+	default:
+		log.Printf("WorkCommander.HandleCallback: unknown team - %s", callbackPath.Subdomain)
+	}
+}
+
+func (c *WorkCommander) HandleCommand(msg *tgbotapi.Message, commandPath path.CommandPath) {
+	switch commandPath.Subdomain {
+	case "team":
+		c.teamCommander.HandleCommand(msg, commandPath)
+	default:
+		log.Printf("WorkCommander.HandleCommand: unknown team - %s", commandPath.Subdomain)
 	}
 }

--- a/internal/app/commands/work/comander.go
+++ b/internal/app/commands/work/comander.go
@@ -22,8 +22,7 @@ func NewWorkCommander(
 	bot *tgbotapi.BotAPI,
 ) *WorkCommander {
 	return &WorkCommander{
-		bot: bot,
-		// teamCommander
+		bot:           bot,
 		teamCommander: team.NewWorkTeamCommander(bot),
 	}
 }

--- a/internal/app/commands/work/comander.go
+++ b/internal/app/commands/work/comander.go
@@ -13,34 +13,34 @@ type Commander interface {
 	HandleCommand(message *tgbotapi.Message, commandPath path.CommandPath)
 }
 
-type WorkCommander struct {
+type workCommander struct {
 	bot           *tgbotapi.BotAPI
 	teamCommander Commander
 }
 
 func NewWorkCommander(
 	bot *tgbotapi.BotAPI,
-) *WorkCommander {
-	return &WorkCommander{
+) *workCommander {
+	return &workCommander{
 		bot:           bot,
 		teamCommander: team.NewWorkTeamCommander(bot),
 	}
 }
 
-func (c *WorkCommander) HandleCallback(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath) {
+func (c *workCommander) HandleCallback(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath) {
 	switch callbackPath.Subdomain {
 	case "team":
 		c.teamCommander.HandleCallback(callback, callbackPath)
 	default:
-		log.Printf("WorkCommander.HandleCallback: unknown team - %s", callbackPath.Subdomain)
+		log.Printf("workCommander.HandleCallback: unknown team - %s", callbackPath.Subdomain)
 	}
 }
 
-func (c *WorkCommander) HandleCommand(msg *tgbotapi.Message, commandPath path.CommandPath) {
+func (c *workCommander) HandleCommand(msg *tgbotapi.Message, commandPath path.CommandPath) {
 	switch commandPath.Subdomain {
 	case "team":
 		c.teamCommander.HandleCommand(msg, commandPath)
 	default:
-		log.Printf("WorkCommander.HandleCommand: unknown team - %s", commandPath.Subdomain)
+		log.Printf("workCommander.HandleCommand: unknown team - %s", commandPath.Subdomain)
 	}
 }

--- a/internal/app/commands/work/comander.go
+++ b/internal/app/commands/work/comander.go
@@ -1,0 +1,27 @@
+package work
+
+import (
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/ozonmp/omp-bot/internal/app/commands/work/team"
+	"github.com/ozonmp/omp-bot/internal/app/path"
+)
+
+type Commander interface {
+	HandleCallback(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath)
+	HandleCommand(message *tgbotapi.Message, commandPath path.CommandPath)
+}
+
+type WorkCommander struct {
+	bot           *tgbotapi.BotAPI
+	teamCommander Commander
+}
+
+func NewWorkCommander(
+	bot *tgbotapi.BotAPI,
+) *WorkCommander {
+	return &WorkCommander{
+		bot: bot,
+		// teamCommander
+		teamCommander: team.NewWorkTeamCommander(bot),
+	}
+}

--- a/internal/app/commands/work/team/callback_list.go
+++ b/internal/app/commands/work/team/callback_list.go
@@ -1,0 +1,33 @@
+package team
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/ozonmp/omp-bot/internal/app/path"
+)
+
+type CallbackListData struct {
+	Offset int `json:"offset"`
+}
+
+func (c *WorkTeamCommander) CallbackList(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath) {
+	parsedData := CallbackListData{}
+	err := json.Unmarshal([]byte(callbackPath.CallbackData), &parsedData)
+	if err != nil {
+		log.Printf("WorkTeamCommander.CallbackList: "+
+			"error reading json data for type CallbackListData from "+
+			"input string %v - %v", callbackPath.CallbackData, err)
+		return
+	}
+	msg := tgbotapi.NewMessage(
+		callback.Message.Chat.ID,
+		fmt.Sprintf("Parsed: %+v\n", parsedData),
+	)
+	_, err = c.bot.Send(msg)
+	if err != nil {
+		log.Printf("WorkTeamCommander.CallbackList: error sending reply message to chat - %v", err)
+	}
+}

--- a/internal/app/commands/work/team/command_delete.go
+++ b/internal/app/commands/work/team/command_delete.go
@@ -1,0 +1,27 @@
+package team
+
+import (
+	"fmt"
+	"strconv"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+func (c *WorkTeamCommander) Delete(inputMessage *tgbotapi.Message) {
+	args := inputMessage.CommandArguments()
+	var msg tgbotapi.MessageConfig
+	teamId, err := strconv.ParseUint(args, 10, 64)
+
+	if err != nil {
+		msg = tgbotapi.NewMessage(inputMessage.Chat.ID, fmt.Sprintf(`Invalid argument "%v"`, args))
+	} else {
+		_, err = c.service.Remove(teamId)
+		if err != nil {
+			msg = tgbotapi.NewMessage(inputMessage.Chat.ID, err.Error())
+		} else {
+			msg = tgbotapi.NewMessage(inputMessage.Chat.ID, "Team was deleted successfully.")
+		}
+	}
+
+	c.bot.Send(msg)
+}

--- a/internal/app/commands/work/team/command_edit.go
+++ b/internal/app/commands/work/team/command_edit.go
@@ -1,0 +1,12 @@
+package team
+
+import (
+	"fmt"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+func (c *WorkTeamCommander) Edit(inputMessage *tgbotapi.Message) {
+	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, fmt.Sprintf("Method Edit is not implimented"))
+	c.bot.Send(msg)
+}

--- a/internal/app/commands/work/team/command_get.go
+++ b/internal/app/commands/work/team/command_get.go
@@ -1,0 +1,31 @@
+package team
+
+import (
+	"fmt"
+	"strconv"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+func (c *WorkTeamCommander) Get(inputMessage *tgbotapi.Message) {
+	args := inputMessage.CommandArguments()
+
+	teamId, err := strconv.ParseUint(args, 10, 64)
+	if err != nil {
+		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, fmt.Sprintf(`Invalid argument "%v"`, args))
+		c.bot.Send(msg)
+
+		return
+	}
+
+	team, err := c.service.Describe(teamId)
+	if err != nil {
+		msg := tgbotapi.NewMessage(inputMessage.Chat.ID, err.Error())
+		c.bot.Send(msg)
+
+		return
+	}
+
+	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, team.String())
+	c.bot.Send(msg)
+}

--- a/internal/app/commands/work/team/command_help.go
+++ b/internal/app/commands/work/team/command_help.go
@@ -1,0 +1,19 @@
+package team
+
+import (
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+func (c *WorkTeamCommander) Help(inputMessage *tgbotapi.Message) {
+	msg := tgbotapi.NewMessage(
+		inputMessage.Chat.ID,
+		`/help__work__team - print list of commands
+		 /get__work__team - get a team by id
+		 /list__work__team - get a list of teams
+		 /delete__work__team - delete an existing team by id
+		 /new__work__team - create a new team.
+		 /edit__work__team - edit a team by id`,
+	)
+
+	c.bot.Send(msg)
+}

--- a/internal/app/commands/work/team/command_list.go
+++ b/internal/app/commands/work/team/command_list.go
@@ -1,0 +1,27 @@
+package team
+
+import (
+	"fmt"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+func (c *WorkTeamCommander) List(inputMessage *tgbotapi.Message) {
+	outputMessage := "All the teams: \n\n"
+	var msg tgbotapi.MessageConfig
+
+	teams, err := c.service.List(0, c.service.Count())
+	if err == nil {
+		for i, t := range teams {
+			outputMessage += fmt.Sprintf("#%d", i+1)
+			outputMessage += t.String()
+			outputMessage += "\n\n"
+		}
+
+		msg = tgbotapi.NewMessage(inputMessage.Chat.ID, outputMessage)
+	} else {
+		msg = tgbotapi.NewMessage(inputMessage.Chat.ID, err.Error())
+	}
+
+	c.bot.Send(msg)
+}

--- a/internal/app/commands/work/team/command_new.go
+++ b/internal/app/commands/work/team/command_new.go
@@ -1,0 +1,12 @@
+package team
+
+import (
+	"fmt"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+)
+
+func (c *WorkTeamCommander) New(inputMessage *tgbotapi.Message) {
+	msg := tgbotapi.NewMessage(inputMessage.Chat.ID, fmt.Sprintf("Method New is not implimented"))
+	c.bot.Send(msg)
+}

--- a/internal/app/commands/work/team/commander.go
+++ b/internal/app/commands/work/team/commander.go
@@ -1,0 +1,52 @@
+package team
+
+import (
+	"log"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"github.com/ozonmp/omp-bot/internal/app/path"
+	workTeamService "github.com/ozonmp/omp-bot/internal/service/work/team"
+	//"github.com/ozonmp/omp-bot/internal/app/commands/work/team"
+)
+
+type TeamCommander interface {
+	Help(inputMsg *tgbotapi.Message)
+	Get(inputMsg *tgbotapi.Message)
+	List(inputMsg *tgbotapi.Message)
+	Delete(inputMsg *tgbotapi.Message)
+
+	New(inputMsg *tgbotapi.Message)  // return error not implemented
+	Edit(inputMsg *tgbotapi.Message) // return error not implemented
+}
+
+type WorkTeamCommander struct {
+	bot     *tgbotapi.BotAPI
+	service workTeamService.TeamService
+}
+
+func (c *WorkTeamCommander) HandleCallback(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath) {
+	switch callbackPath.Subdomain {
+	case "team":
+		c.HandleCallback(callback, callbackPath)
+	default:
+		log.Printf("WorkCommander.HandleCallback: unknown team - %s", callbackPath.Subdomain)
+	}
+}
+
+func (c *WorkTeamCommander) HandleCommand(msg *tgbotapi.Message, commandPath path.CommandPath) {
+	switch commandPath.Subdomain {
+	case "team":
+		c.HandleCommand(msg, commandPath)
+	default:
+		log.Printf("WorkCommander.HandleCommand: unknown team - %s", commandPath.Subdomain)
+	}
+}
+
+func NewWorkTeamCommander(bot *tgbotapi.BotAPI) *WorkTeamCommander {
+	service := workTeamService.NewWorkTeamService()
+
+	return &WorkTeamCommander{
+		bot:     bot,
+		service: service,
+	}
+}

--- a/internal/app/commands/work/team/commander.go
+++ b/internal/app/commands/work/team/commander.go
@@ -6,7 +6,6 @@ import (
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/ozonmp/omp-bot/internal/app/path"
 	workTeamService "github.com/ozonmp/omp-bot/internal/service/work/team"
-	//"github.com/ozonmp/omp-bot/internal/app/commands/work/team"
 )
 
 type TeamCommander interface {
@@ -24,29 +23,39 @@ type WorkTeamCommander struct {
 	service workTeamService.TeamService
 }
 
-func (c *WorkTeamCommander) HandleCallback(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath) {
-	switch callbackPath.Subdomain {
-	case "team":
-		c.HandleCallback(callback, callbackPath)
-	default:
-		log.Printf("WorkCommander.HandleCallback: unknown team - %s", callbackPath.Subdomain)
-	}
-}
-
-func (c *WorkTeamCommander) HandleCommand(msg *tgbotapi.Message, commandPath path.CommandPath) {
-	switch commandPath.Subdomain {
-	case "team":
-		c.HandleCommand(msg, commandPath)
-	default:
-		log.Printf("WorkCommander.HandleCommand: unknown team - %s", commandPath.Subdomain)
-	}
-}
-
 func NewWorkTeamCommander(bot *tgbotapi.BotAPI) *WorkTeamCommander {
 	service := workTeamService.NewWorkTeamService()
 
 	return &WorkTeamCommander{
 		bot:     bot,
 		service: service,
+	}
+}
+
+func (c *WorkTeamCommander) HandleCallback(callback *tgbotapi.CallbackQuery, callbackPath path.CallbackPath) {
+	switch callbackPath.CallbackName {
+	case "list":
+		c.CallbackList(callback, callbackPath)
+	default:
+		log.Printf("WorkTeamCommander.HandleCallback: unknown callback name: %s", callbackPath.CallbackName)
+	}
+}
+
+func (c *WorkTeamCommander) HandleCommand(msg *tgbotapi.Message, commandPath path.CommandPath) {
+	switch commandPath.CommandName {
+	case "help":
+		c.Help(msg)
+	case "get":
+		c.Get(msg)
+	case "list":
+		c.List(msg)
+	case "delete":
+		c.Delete(msg)
+	case "new":
+		c.New(msg)
+	case "edit":
+		c.Edit(msg)
+	default:
+		log.Printf("WorkTeamCommander.HandleCommand: unknown CommandName: %s", commandPath.CommandName)
 	}
 }

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -5,6 +5,7 @@ import (
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 	"github.com/ozonmp/omp-bot/internal/app/commands/demo"
+	"github.com/ozonmp/omp-bot/internal/app/commands/work"
 	"github.com/ozonmp/omp-bot/internal/app/path"
 )
 
@@ -35,6 +36,7 @@ type Router struct {
 	// streaming
 	// business
 	// work
+	workCommander Commander
 	// service
 	// exchange
 	// estate
@@ -70,6 +72,7 @@ func NewRouter(
 		// streaming
 		// business
 		// work
+		workCommander: work.NewWorkCommander(bot),
 		// service
 		// exchange
 		// estate
@@ -138,6 +141,7 @@ func (c *Router) handleCallback(callback *tgbotapi.CallbackQuery) {
 	case "business":
 		break
 	case "work":
+		c.workCommander.HandleCallback(callback, callbackPath)
 		break
 	case "service":
 		break
@@ -209,6 +213,7 @@ func (c *Router) handleMessage(msg *tgbotapi.Message) {
 	case "business":
 		break
 	case "work":
+		c.workCommander.HandleCommand(msg, commandPath)
 		break
 	case "service":
 		break

--- a/internal/model/work/team.go
+++ b/internal/model/work/team.go
@@ -1,0 +1,38 @@
+package work
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const prettyPrintFormat = `{
+	id: %d
+	name: %s
+	description: %s
+	size: %d
+	created_at: %s
+}`
+
+type Team struct {
+	ID          uint64 `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Size        uint64 `json:"size"`
+	CreatedAt   string `json:"created_at"`
+}
+
+func (t *Team) String() string {
+	str, _ := json.Marshal(t)
+	return fmt.Sprintf(`%s`, string(str))
+}
+
+func (t *Team) PrettyPrint() string {
+	return fmt.Sprintf(
+		prettyPrintFormat,
+		t.ID,
+		t.Name,
+		t.Description,
+		t.Size,
+		t.CreatedAt,
+	)
+}

--- a/internal/model/work/team.go
+++ b/internal/model/work/team.go
@@ -1,7 +1,6 @@
 package work
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
@@ -22,11 +21,6 @@ type Team struct {
 }
 
 func (t *Team) String() string {
-	str, _ := json.Marshal(t)
-	return fmt.Sprintf(`%s`, string(str))
-}
-
-func (t *Team) PrettyPrint() string {
 	return fmt.Sprintf(
 		prettyPrintFormat,
 		t.ID,

--- a/internal/service/work/team/const.go
+++ b/internal/service/work/team/const.go
@@ -1,0 +1,3 @@
+package team
+
+const entityNotFound = "Entity not found with teamID=%d"

--- a/internal/service/work/team/interface.go
+++ b/internal/service/work/team/interface.go
@@ -10,6 +10,7 @@ type TeamService interface {
 	Create(work.Team) (uint64, error)
 	Update(teamID uint64, team work.Team) error
 	Remove(teamID uint64) (bool, error)
+	Count() uint64
 }
 
 func NewWorkTeamService() *WorkTeamService {

--- a/internal/service/work/team/interface.go
+++ b/internal/service/work/team/interface.go
@@ -14,5 +14,13 @@ type TeamService interface {
 }
 
 func NewWorkTeamService() *WorkTeamService {
-	return &WorkTeamService{}
+	entitiesMock := make(map[uint64]work.Team)
+
+	for _, item := range teamMocks {
+		entitiesMock[item.ID] = item
+	}
+
+	return &WorkTeamService{
+		entities: entitiesMock,
+	}
 }

--- a/internal/service/work/team/interface.go
+++ b/internal/service/work/team/interface.go
@@ -1,0 +1,17 @@
+package team
+
+import (
+	"github.com/ozonmp/omp-bot/internal/model/work"
+)
+
+type TeamService interface {
+	Describe(teamID uint64) (*work.Team, error)
+	List(cursor uint64, limit uint64) ([]work.Team, error)
+	Create(work.Team) (uint64, error)
+	Update(teamID uint64, team work.Team) error
+	Remove(teamID uint64) (bool, error)
+}
+
+func NewWorkTeamService() *WorkTeamService {
+	return &WorkTeamService{}
+}

--- a/internal/service/work/team/mock.go
+++ b/internal/service/work/team/mock.go
@@ -1,0 +1,37 @@
+package team
+
+import (
+	"github.com/ozonmp/omp-bot/internal/model/work"
+)
+
+var teamMocks = []work.Team{
+	{
+		ID:          1,
+		Name:        "NaVi",
+		Description: "Natus Vincere - team Dota 2",
+		Size:        5,
+		CreatedAt:   "15-10-2010",
+	},
+	{
+		ID:          2,
+		Name:        "Team Spirit",
+		Description: "Russian team Dota 2",
+		Size:        5,
+		CreatedAt:   "15-09-2005",
+	},
+
+	{
+		ID:          3,
+		Name:        "Лена Кукв",
+		Description: "Команда КВН",
+		Size:        3,
+		CreatedAt:   "15-04-2007",
+	},
+	{
+		ID:          4,
+		Name:        "PSG",
+		Description: "PSG (Paris Saint-Germain) - футбольная команда",
+		Size:        11,
+		CreatedAt:   "15-09-1970",
+	},
+}

--- a/internal/service/work/team/service.go
+++ b/internal/service/work/team/service.go
@@ -83,3 +83,7 @@ func (w *WorkTeamService) Remove(teamID uint64) (bool, error) {
 
 	return true, nil
 }
+
+func (w *WorkTeamService) Count() uint64 {
+	return uint64(len(w.entities))
+}

--- a/internal/service/work/team/service.go
+++ b/internal/service/work/team/service.go
@@ -5,8 +5,6 @@ import (
 	"log"
 
 	"github.com/ozonmp/omp-bot/internal/model/work"
-	// 	"errors"
-	// "fmt"
 )
 
 type WorkTeamService struct {

--- a/internal/service/work/team/service.go
+++ b/internal/service/work/team/service.go
@@ -1,0 +1,85 @@
+package team
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/ozonmp/omp-bot/internal/model/work"
+	// 	"errors"
+	// "fmt"
+)
+
+type WorkTeamService struct {
+	entities map[uint64]work.Team
+}
+
+func (w *WorkTeamService) Describe(teamID uint64) (*work.Team, error) {
+	log.Printf("Work.TeamService: getting team with id %v", teamID)
+
+	entity, ok := w.entities[teamID]
+	if !ok {
+		return nil, fmt.Errorf(entityNotFound, teamID)
+	}
+
+	return &entity, nil
+}
+
+func (w *WorkTeamService) List(cursor uint64, limit uint64) ([]work.Team, error) {
+	log.Printf("Work.TeamService: listing teams in range from %v to %v", cursor, cursor+limit)
+
+	count := uint64(len(w.entities))
+	if cursor > count {
+		return []work.Team{}, fmt.Errorf("IndexOutOfRange, cursor=%d", cursor)
+	} else if count == 0 {
+		return []work.Team{}, nil
+	}
+
+	maxIndex := cursor + limit
+	if maxIndex > count {
+		maxIndex = count
+	}
+
+	lst := make([]work.Team, 0, limit)
+	for _, val := range w.entities {
+		lst = append(lst, val)
+	}
+
+	return lst, nil
+}
+
+func (w *WorkTeamService) Create(newTeam work.Team) (uint64, error) {
+	log.Printf("Work.TeamService: creating team %#v", newTeam)
+
+	w.entities[newTeam.ID] = newTeam
+
+	return uint64(len(w.entities)), nil
+}
+
+func (w *WorkTeamService) Update(teamID uint64, team work.Team) error {
+	log.Printf("Work.TeamService: updating team %v with value: %#v", teamID, team)
+
+	entity, ok := w.entities[teamID]
+
+	if !ok {
+		return fmt.Errorf(entityNotFound, teamID)
+	}
+
+	entity.Name = team.Name
+	entity.Description = team.Description
+	entity.Size = team.Size
+	entity.CreatedAt = team.CreatedAt
+
+	return nil
+}
+
+func (w *WorkTeamService) Remove(teamID uint64) (bool, error) {
+	log.Printf("Work.TeamService: deleting team with id %v", teamID)
+
+	if _, ok := w.entities[teamID]; !ok {
+		return false, fmt.Errorf(entityNotFound, teamID)
+	}
+
+	delete(w.entities, teamID)
+
+	return true, nil
+}


### PR DESCRIPTION
List add commands:

- /help__{domain}__{subdomain} — print list of commands
- /get__{domain}__{subdomain} — get a entity
- /list__{domain}__{subdomain} — get a list of your entity (💎: with pagination via telegram keyboard)
- /delete__{domain}__{subdomain} — delete an existing entity
- /new__{domain}__{subdomain} — create a new entity // not implemented (💎: implement list fields via arguments)
- /edit__{domain}__{subdomain} — edit a entity      // not implemented